### PR TITLE
fixed glide installation instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,18 @@ $ export GOBIN=$GOPATH/bin
 $ export PATH=$PATH:$GOBIN
 ```
 
-- Install glide (package management). https://github.com/Masterminds/glide
+- Install glide (package management). https://github.com/Masterminds/glide (instructions copied below)
 
-```bashN
-$ curl https://glide.sh/get | sh
+On Mac OS X you can install the latest release via [Homebrew](https://github.com/Homebrew/homebrew):
+
+```
+$ brew install glide
+```
+
+On Ubuntu install the package `golang-glide`:
+
+```
+$ sudo apt install golang-glide
 ```
 
 - Install lint libs


### PR DESCRIPTION
Installation instructions for glide package manager refer to the domain `glide.sh` which is at the moment parked and seems inactive. This could potentially facilitate a supply chain attack on devs` computers, since instructions are recommending to pipe whatever the http request returns straight into `sh`.  This also breaks the current installation instructions.  I propose to update the installation instructions to use respective package managers for OSX and Ubuntu.